### PR TITLE
[BUGFIX] Generate cHash for every link with TYPO3 9

### DIFF
--- a/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
+++ b/Tests/Unit/Domain/Search/Uri/SearchUriBuilderTest.php
@@ -30,6 +30,7 @@ use ApacheSolrForTypo3\Solr\Domain\Search\SearchRequest;
 use ApacheSolrForTypo3\Solr\System\Configuration\TypoScriptConfiguration;
 use ApacheSolrForTypo3\Solr\Tests\Unit\UnitTest;
 use ApacheSolrForTypo3\Solr\Domain\Search\Uri\SearchUriBuilder;
+use ApacheSolrForTypo3\Solr\Util;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 
 /**
@@ -69,9 +70,17 @@ class SearchUriBuilderTest extends UnitTest
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
 
-        $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']]];
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']]];
+            $cHashIsUsed = false;
+        } else {
+            $expectedArguments = ['tx_solr' => ['filter' => ['foo:bar']]];
+            $cHashIsUsed = true;
+        }
+
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'foo', 'bar');
@@ -82,21 +91,29 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function addFacetLinkWillAddAdditionalConfiguredArguments()
     {
-        $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']], '###tx_solr:0###'];
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $expectedArguments = ['tx_solr' => ['filter' => ['###tx_solr:filter:0###']], '###tx_solr:0###'];
+            $linkBuilderResult = 'filter='.urlencode('###tx_solr:filter:0###').'&'.urlencode('###tx_solr:0###');
+            $cHashIsUsed = false;
+        } else {
+            $expectedArguments = ['tx_solr' => ['filter' => ['option:value']], 'foo=bar'];
+            $linkBuilderResult = 'filter='.urlencode('option:value').'&'.urlencode('foo=bar');
+            $cHashIsUsed = true;
+        }
 
-        $result = 'filter='.urlencode('###tx_solr:filter:0###').'&'.urlencode('###tx_solr:0###');
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->with()->will($this->returnValue($result));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->with()->will($this->returnValue($linkBuilderResult));
 
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
 
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue(['foo=bar']));
         $previousRequest =  new SearchRequest([], 1, 0, $configurationMock);
-        $result = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'option', 'value');
+        $linkBuilderResult = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'option', 'value');
 
-        $this->assertEquals($result, 'filter=option%3Avalue&foo%3Dbar');
+        $this->assertEquals($linkBuilderResult, 'filter=option%3Avalue&foo%3Dbar');
     }
 
     /**
@@ -104,6 +121,11 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function setArgumentsIsOnlyCalledOnceEvenWhenMultipleFacetsGetRendered()
     {
+        // @todo This test can be dropped when TYPO3 8 support is dropped
+        if (!Util::getIsTYPO3VersionBelow9()) {
+            $this->markTestSkipped('This scenario is only relevant for TYPO3 8 when the typolink cache is active');
+        }
+
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
         $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
@@ -124,25 +146,75 @@ class SearchUriBuilderTest extends UnitTest
         $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'red');
     }
 
+    /**
+     * @test
+     */
+    public function setArgumentsIsCalledForEveryArgument()
+    {
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped, the test can be kept for 9 LTS
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $this->markTestSkipped('This scenario is only relevant for TYPO3 8 when the typolink cache is active');
+        }
+
+        $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
+        $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
+        $configurationMock->expects($this->once())->method('getSearchFacetingFacetLinkUrlParametersAsArray')->will($this->returnValue([]));
+
+        $this->extBaseUriBuilderMock->expects($this->exactly(3))->method('setArguments')
+            ->withConsecutive(
+                [['tx_solr' => ['filter' => ['color:green']]]],
+                [['tx_solr' => ['filter' => ['color:blue']]]],
+                [['tx_solr' => ['filter' => ['color:red']]]]
+            )->will($this->returnValue($this->extBaseUriBuilderMock));
+
+        $this->extBaseUriBuilderMock->expects($this->exactly(3))->method('setUseCacheHash')->with(true)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->exactly(3))->method('build')->will(
+            $this->onConsecutiveCalls(
+                urlencode('tx_solr[filter][0]=color:green'),
+                urlencode('tx_solr[filter][0]=color:blue'),
+                urlencode('tx_solr[filter][0]=color:red')
+            )
+        );
+
+        $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
+        $previousRequest->removeAllFacets();
+        $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'green');
+
+        $previousRequest->removeAllFacets();
+        $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'blue');
+
+        $previousRequest->removeAllFacets();
+        $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'color', 'red');
+    }
+
 
     /**
      * @test
      */
     public function targetPageUidIsPassedWhenSortingIsAdded()
     {
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
+            $linkBuilderResult = 'tx_solr[sort]='.urlencode('###tx_solr:sort###');
+            $cHashIsUsed = false;
+        } else {
+            $expectedArguments = ['tx_solr' => ['sort' => 'title desc']];
+            $linkBuilderResult = 'tx_solr[sort]='.urlencode('title desc');
+            $cHashIsUsed = true;
+        }
+
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->once())->method('getSearchTargetPage')->will($this->returnValue(4711));
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
 
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
 
-        $expectedArguments = ['tx_solr' => ['sort' => '###tx_solr:sort###']];
-
             // we expect that the page uid from the configruation will be used to build the url with the uri builder
         $this->extBaseUriBuilderMock->expects($this->once())->method('setTargetPageUid')->with(4711)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue('tx_solr[sort]='.urlencode('###tx_solr:sort###')));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
         $result = $this->searchUrlBuilder->getSetSortingUri($previousRequest, 'title', 'desc');
         $this->assertEquals('tx_solr[sort]=title+desc', $result);
     }
@@ -152,6 +224,13 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function canGetRemoveFacetOptionUri()
     {
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $cHashIsUsed = false;
+        } else {
+            $cHashIsUsed = true;
+        }
+
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
 
@@ -169,7 +248,7 @@ class SearchUriBuilderTest extends UnitTest
         // we expect that the filters are empty after remove
         $expectedArguments = ['tx_solr' => ['filter' => []]];
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->searchUrlBuilder->getRemoveFacetValueUri($previousRequest, 'type', 'pages');
     }
 
@@ -178,6 +257,13 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function canGetRemoveFacetUri()
     {
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $cHashIsUsed = false;
+        } else {
+            $cHashIsUsed = true;
+        }
+
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
 
@@ -197,7 +283,7 @@ class SearchUriBuilderTest extends UnitTest
         //@todo we need to refactor the request in ext:solr to cleanup empty arguments completely to assert  $expectedArguments = []
         $expectedArguments = ['tx_solr' => ['filter' => []]];
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
         $this->searchUrlBuilder->getRemoveFacetUri($previousRequest, 'type');
     }
 
@@ -221,6 +307,11 @@ class SearchUriBuilderTest extends UnitTest
                 ]
             ],
             0, 0, $configurationMock);
+
+        $this->extBaseUriBuilderMock->expects($this->any())->method('setArguments')->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->any())->method('setUseCacheHash')->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->any())->method('build')->will($this->returnValue('tx_solr[filter][0]=type:pages'));
+
         $uri = $this->searchUrlBuilder->getAddFacetValueUri($previousRequest, 'type', 'pages');
         $this->assertSame('tx_solr[filter][0]=type:pages', urldecode($uri), 'Unexpected uri generated');
     }
@@ -230,6 +321,33 @@ class SearchUriBuilderTest extends UnitTest
      */
     public function canSetGroupPageForQueryGroup()
     {
+        // @todo This check can be dropped with TYPO3 8 LTS support is dropped
+        if (Util::getIsTYPO3VersionBelow9()) {
+            $cHashIsUsed = false;
+            $expectedArguments = [
+                'tx_solr' => [
+                    'groupPage' => [
+                        'smallPidRange' => [
+                            'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###'
+                        ]
+                    ]
+                ]
+            ];
+            $linkBuilderResult = 'tx_solr[groupPage][smallPidRange][pid0to5]='.urlencode('###tx_solr:groupPage:smallPidRange:pid0to5###');
+        } else {
+            $cHashIsUsed = true;
+            $expectedArguments = [
+                'tx_solr' => [
+                    'groupPage' => [
+                        'smallPidRange' => [
+                            'pid0to5' => '5'
+                        ]
+                    ]
+                ]
+            ];
+            $linkBuilderResult = 'tx_solr[groupPage][smallPidRange][pid0to5]='.urlencode('5');
+        }
+
         $configurationMock = $this->getDumbMock(TypoScriptConfiguration::class);
         $configurationMock->expects($this->any())->method('getSearchPluginNamespace')->will($this->returnValue('tx_solr'));
         $previousRequest =  new SearchRequest([], 0, 0, $configurationMock);
@@ -237,18 +355,10 @@ class SearchUriBuilderTest extends UnitTest
         $group = new Group('smallPidRange', 5);
         $groupItem = new GroupItem($group, 'pid:[0 to 5]', 12, 0, 32);
 
-        $expectedArguments = [
-            'tx_solr' => [
-                'groupPage' => [
-                   'smallPidRange' => [
-                       'pid0to5' => '###tx_solr:groupPage:smallPidRange:pid0to5###'
-                   ]
-                ]
-            ]
-        ];
+
         $this->extBaseUriBuilderMock->expects($this->once())->method('setArguments')->with($expectedArguments)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with(false)->will($this->returnValue($this->extBaseUriBuilderMock));
-        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue('tx_solr[groupPage][smallPidRange][pid0to5]='.urlencode('###tx_solr:groupPage:smallPidRange:pid0to5###')));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('setUseCacheHash')->with($cHashIsUsed)->will($this->returnValue($this->extBaseUriBuilderMock));
+        $this->extBaseUriBuilderMock->expects($this->once())->method('build')->will($this->returnValue($linkBuilderResult));
         $uri = $this->searchUrlBuilder->getResultGroupItemPageUri($previousRequest, $groupItem, 5);
         $this->assertContains('tx_solr[groupPage][smallPidRange][pid0to5]=5', $uri, 'Uri did not contain link segment for query group');
     }


### PR DESCRIPTION
This pr:

* Deactivates the in memory cache for typolink calls for facet links for TYPO3 9 since the site handling requires a cHash for all links

Fixes: #2211